### PR TITLE
Use logging-facade for *all* error reporting.

### DIFF
--- a/src/Kraken/Run.hs
+++ b/src/Kraken/Run.hs
@@ -27,7 +27,6 @@ import           Options.Applicative      hiding (action)
 import           Prelude                  hiding (mapM)
 import           Safe
 import           System.Exit
-import           System.IO
 import           Text.Printf
 
 import qualified System.Logging.Facade as Log
@@ -82,7 +81,7 @@ runStore opts krakenConfig store = case opts of
   where
     reportAndExit :: [Error] -> IO ()
     reportAndExit messages = do
-        hPutStr stderr $ unlines $
+        Log.info . unlines $
             "" :
             "FAILURE" :
             "-------" :

--- a/test/KrakenSpec.hs
+++ b/test/KrakenSpec.hs
@@ -111,11 +111,12 @@ spec = do
             , "INFO: running target foo"
             , "ERROR: foo:"
             , "    some error"
-            , ""
+            , "INFO: "
             , "FAILURE"
             , "-------"
             , "foo:"
             , "    some error"
+            , ""
             ]
 
         it "exits with ExitFailure 70 (internal software error)" $ do


### PR DESCRIPTION
There're a few remaining occurences of `hPutStrLn stderr` in the test cases (precisely `RunSpec` and `ActionMSpec`), but the messages there aren't errors as such, just conveniently capturable side-effects, so I left them alone.